### PR TITLE
Adding sirv-cli for local server

### DIFF
--- a/default/package.json
+++ b/default/package.json
@@ -2,13 +2,15 @@
   "name": "todo",
   "type": "module",
   "scripts": {
-    "build": "microsite build"
+    "build": "microsite build",
+    "serve": "sirv dist -s"
   },
   "devDependencies": {
-    "microsite": "0.6.14",
+    "microsite": "^0.7.0",
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
     "prettier": "^2.1.2",
+    "sirv-cli": "^1.0.8",
     "typescript": "^4.1.2"
   },
   "husky": {


### PR DESCRIPTION
I noticed on the main repo you have some sort of plan for file serving (https://github.com/natemoo-re/microsite/issues/44#issue-749799715) but in the meantime `sirv-cli` here can be a super useful addition. Useful as a production-like server too, so it could have a life after the `--watch --serve` is implemented.

`sirv-cli` is a super lightweight server to serve static assets: https://github.com/lukeed/sirv/tree/master/packages/sirv-cli. Dead-simple to setup and fast. 

Also bumped `microsite` to latest as in the listed version I get a `SyntaxError: The keyword 'interface' is reserved (5:0) ...`. This disappears on latest.